### PR TITLE
Properly output running config for filters

### DIFF
--- a/src/filter.cc
+++ b/src/filter.cc
@@ -47,5 +47,6 @@ void Filter::BaseDescription::config(YAML::Node const &) {
 
 YAML::Node Filter::dump_config() {
     YAML::Node node;
+    do_dump_config(node);
     return node;
 }


### PR DESCRIPTION
The call to do_dump_config was missing from the Filter::dump_config call, meaning that the config was never actually output.