### PR TITLE
Bugfixes to Stanza lib

### DIFF
--- a/src/dialback.cc
+++ b/src/dialback.cc
@@ -61,7 +61,7 @@ namespace {
 
         bool negotiate(optional_ptr<rapidxml::xml_node<>>) override { // Note that this offer, unusually, can be nullptr.
             if (!m_stream.secured() && (Config::config().domain(m_stream.remote_domain()).require_tls())) {
-                m_stream.logger().info("Supressed dialback due to missing required TLS");
+                m_stream.logger().info("Suppressed dialback due to missing required TLS");
                 return false;
             }
             m_stream.set_auth_ready();

--- a/tests/endpoint.cc
+++ b/tests/endpoint.cc
@@ -75,11 +75,7 @@ public:
         ASSERT_EQ(stanza.type_str(), std::string("error"));
         // Now reparse the stanza.
         std::string xml;
-        {
-            rapidxml::xml_document<> doc;
-            stanza.render(doc);
-            rapidxml::print(std::back_inserter(xml), doc, rapidxml::print_no_indenting);
-        }
+        rapidxml::print(std::back_inserter(xml), stanza.node().value(), rapidxml::print_no_indenting);
         rapidxml::xml_document<> doc;
         doc.parse<rapidxml::parse_full>(const_cast<char *>(xml.c_str()));
         auto msg = doc.first_node("message");
@@ -107,11 +103,7 @@ public:
         ASSERT_EQ(stanza.type_str(), std::string("result"));
         // Now reparse the stanza.
         std::string xml;
-        {
-            rapidxml::xml_document<> doc;
-            stanza.render(doc);
-            rapidxml::print(std::back_inserter(xml), doc, rapidxml::print_no_indenting);
-        }
+        rapidxml::print(std::back_inserter(xml), stanza.node().value(), rapidxml::print_no_indenting);
         rapidxml::xml_document<> doc;
         doc.parse<rapidxml::parse_full>(const_cast<char *>(xml.c_str()));
         std::unique_ptr<Iq> iq{new Iq(doc.first_node())};
@@ -138,11 +130,7 @@ public:
         ASSERT_EQ(stanza.type_str(), std::string("result"));
         // Now reparse the stanza.
         std::string xml;
-        {
-            rapidxml::xml_document<> doc;
-            stanza.render(doc);
-            rapidxml::print(std::back_inserter(xml), doc, rapidxml::print_no_indenting);
-        }
+        rapidxml::print(std::back_inserter(xml), stanza.node().value(), rapidxml::print_no_indenting);
         rapidxml::xml_document<> doc;
         doc.parse<rapidxml::parse_full>(const_cast<char *>(xml.c_str()));
         std::unique_ptr<Iq> iq{new Iq(doc.first_node())};

--- a/tests/stanza.cc
+++ b/tests/stanza.cc
@@ -20,10 +20,8 @@ public:
     }
 
     static std::string print(Stanza & s) {
-        rapidxml::xml_document<> tmp_doc;
         std::string tmp_buffer;
-        s.render(tmp_doc);
-        rapidxml::print(std::back_inserter(tmp_buffer), *(tmp_doc.first_node()), rapidxml::print_no_indenting);
+        rapidxml::print(std::back_inserter(tmp_buffer), *(s.node()), rapidxml::print_no_indenting);
         return tmp_buffer;
     }
 };
@@ -132,11 +130,11 @@ TEST_F(MessageTest, MessageReplaceBodyDouble) {
         auto body3 = msg->node()->first_node("body");
         EXPECT_EQ(body3->value(), "Replacement body");
         std::string replacement("New replacement body");
-        body3->value(replacement);
-        auto body4 = msg->node()->first_node("body");
-        EXPECT_TRUE(body4);
-        EXPECT_EQ(body4->value(), "New replacement body");
+        body3->value(body3->document()->allocate_string(replacement));
     }
+    auto body4 = msg->node()->first_node("body");
+    EXPECT_TRUE(body4);
+    EXPECT_EQ(body4->value(), "New replacement body");
 }
 
 TEST_F(MessageTest, MessageReplaceBodyDoubleQuotes) {
@@ -252,7 +250,7 @@ TEST_F(MessageTest, Encapsulate) {
     auto container = msg->node()->append_element({"urn:xmpp:container", "container"});
     container->append_node(msg->node()->document()->clone_node(saved, true));
     auto tmp_buffer = print(*msg);
-    std::string expected = "<message to=\"bar@example.net/laks\" from=\"foo@example.org/lmas\" type=\"chat\" id=\"1234\"><container xmlns=\"urn:xmpp:container\"><message from=\"foo@example.org/lmas\" to=\"bar@example.net/laks\" type=\"chat\" id=\"1234\" xmlns=\"jabber:client\"><body>This is the body &amp; stuff</body></message></container></message>";
+    std::string expected = "<message to=\"bar@example.net/laks\" from=\"foo@example.org/lmas\" type=\"chat\" id=\"1234\"><container xmlns=\"urn:xmpp:container\"><message to=\"bar@example.net/laks\" from=\"foo@example.org/lmas\" type=\"chat\" id=\"1234\" xmlns=\"jabber:client\"><body>This is the body &amp; stuff</body></message></container></message>";
     EXPECT_EQ(tmp_buffer, expected);
 }
 


### PR DESCRIPTION
Turns out the tests were using Stanza::render still, but the XMLStream no longer does.

* Stanza::render has been removed
* Stanza::rewrite_node added to cleanup root node when attributes are changed.
* Added missing support for xml:lang
* Bugfixes to DB pseudo-stanzas.