### PR TITLE
Don't load context when checking if enabled

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -159,7 +159,7 @@ namespace {
             if (tls["x509"]) {
                 dom->tls_context().add_identity(std::make_unique<PKIXIdentity>(tls["x509"]));
             }
-            dom->tls_context().enabled(); // Force everything to get instantiated here.
+            dom->tls_context().context(); // Force everything to get instantiated here.
             if (tls["validation"]) {
                 dom->pkix_validator(std::make_unique<PKIXValidator>(tls["validation"]));
                 dom->pkix_validator().load(); // Force loading here.
@@ -367,12 +367,14 @@ void Config::load(std::string const &filename, bool lite) {
             m_healthcheck_tls = std::make_unique<TLSContext>(globals["healthcheck"]["tls"], "healthcheck");
             logger().debug("Found healthcheck info, will bail if lite mode is on: {}", lite);
             if (lite) return;
-            m_healthcheck_tls->enabled();
+            m_healthcheck_tls->context();
             if (globals["healthcheck"]["checks"]) {
                 for (auto const & from : globals["healthcheck"]["checks"]) {
                     m_healthchecks.emplace(from.first.as<std::string>(), from.second.as<std::string>());
                 }
             }
+        } else {
+            m_healthcheck_tls = std::make_unique<TLSContext>(globals["healthcheck"], "healthcheck"); // Non-existent node to gain defaults
         }
         logger().debug("Completed globals, will bail if lite mode is on: {}", lite);
         if (lite) return;

--- a/src/pkix.cc
+++ b/src/pkix.cc
@@ -551,7 +551,7 @@ void PKIXIdentity::apply(SSL_CTX * ssl_ctx) const {
 }
 
 bool TLSContext::enabled() {
-    return context() != nullptr;
+    return m_enabled;
 }
 
 void TLSContext::add_identity(std::unique_ptr<PKIXIdentity> &&identity) {


### PR DESCRIPTION
This isn't a huge thing, but it makes fixing other bugs easier