### PR TITLE
Avoid auth with JWT, test JWT

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -365,11 +365,11 @@ void Config::load(std::string const &filename, bool lite) {
             m_healthcheck_port = globals["healthcheck"]["port"].as<unsigned short>(m_healthcheck_port);
             m_healthcheck_address = globals["healthcheck"]["address"].as<std::string>(m_healthcheck_address);
             m_healthcheck_tls = std::make_unique<TLSContext>(globals["healthcheck"]["tls"], "healthcheck");
+            logger().debug("Found healthcheck info, will bail if lite mode is on: {}", lite);
+            if (lite) return;
             if (globals["healthcheck"]["jwt_pub_key"]) {
                 m_healthcheck_verifier = std::make_unique<JWTVerifier>(globals["healthcheck"]["jwt_pub_key"].as<std::string>());
             }
-            logger().debug("Found healthcheck info, will bail if lite mode is on: {}", lite);
-            if (lite) return;
             m_healthcheck_tls->context();
             if (globals["healthcheck"]["checks"]) {
                 for (auto const & from : globals["healthcheck"]["checks"]) {

--- a/src/mainloop.cc
+++ b/src/mainloop.cc
@@ -196,8 +196,16 @@ namespace Metre {
                     evhttp_send_error(req, HTTP_BADMETHOD, "Method not supported");
                     co_return;
             }
+            bool check_auth = true;
             auto headers = evhttp_request_get_input_headers(req);
-            if (Config::config().healthcheck_auth()) {
+            auto connection = evhttp_request_get_connection(req);
+            char * host = nullptr;
+            uint16_t port = 0;
+            evhttp_connection_get_peer(connection, &host, &port);
+            if (host && host == std::string("127.0.0.1")) {
+                check_auth = false;
+            }
+            if (check_auth && Config::config().healthcheck_auth()) {
                 auto authz = evhttp_find_header(headers, "authorization");
                 if (!authz) {
                     evhttp_send_error(req, HTTP_BADREQUEST, "No header");


### PR DESCRIPTION
Local healthchecks (assumed to be coming from localhost), including Docker healthchecks, should not be subject to JWT auth.

JWT keys should be loadable from files.